### PR TITLE
Improve Payment Session model and introduce Create service

### DIFF
--- a/app/services/spree_adyen/payment_sessions/create.rb
+++ b/app/services/spree_adyen/payment_sessions/create.rb
@@ -1,0 +1,29 @@
+module SpreeAdyen
+  module PaymentSessions
+    class Create
+      def initialize(order:, user:, amount:, payment_method:)
+        @order = order
+        @amount = amount
+        @user = user
+        @payment_method = payment_method
+      end
+
+      def call
+        response = payment_method.create_payment_session(amount, order)
+        return unless response.success?
+
+        PaymentSession.create!(
+          adyen_id: response.params['id'],
+          order: order,
+          amount: amount,
+          adyen_data: response.params['sessionData'],
+          user: user,
+          expires_at: response.params['expiresAt'],
+          payment_method: payment_method
+        )
+      end
+
+      attr_reader :order, :payment_method, :amount, :user
+    end
+  end
+end

--- a/app/services/spree_adyen/payment_sessions/find_or_create.rb
+++ b/app/services/spree_adyen/payment_sessions/find_or_create.rb
@@ -11,19 +11,7 @@ module SpreeAdyen
       def call
         return payment_session if payment_session.present?
 
-        response = payment_method.create_payment_session(amount, order)
-        return unless response.success?
-
-        PaymentSession.create!(
-          adyen_id: response.params['id'],
-          order: order,
-          amount: amount,
-          currency: order.currency,
-          adyen_data: response.params['sessionData'],
-          user: user,
-          expires_at: response.params['expiresAt'],
-          payment_method: payment_method
-        )
+        Create.new(order: order, user: user, amount: amount, payment_method: payment_method).call
       end
 
       private

--- a/db/migrate/20250630150000_setup_spree_adyen_models.rb
+++ b/db/migrate/20250630150000_setup_spree_adyen_models.rb
@@ -8,11 +8,9 @@ class SetupSpreeAdyenModels < ActiveRecord::Migration[7.2]
       t.string :status, null: false, index: true
       t.datetime :expires_at, null: false, index: true
       t.references :payment_method, null: false, index: true
-      t.string :adyen_id, null: false, index: true
+      t.string :adyen_id, null: false, index: { unique: true }
       t.text :adyen_data, null: false
       t.timestamps
-
-      t.index %w[payment_method_id adyen_id], unique: true
     end
   end
 end

--- a/lib/spree_adyen/testing_support/factories/payment_session_factory.rb
+++ b/lib/spree_adyen/testing_support/factories/payment_session_factory.rb
@@ -1,11 +1,10 @@
 FactoryBot.define do
   factory :payment_session, class: SpreeAdyen::PaymentSession do
-    adyen_id { 'pi_123' }
+    sequence(:adyen_id) { |n| "pi_#{n}" }
     adyen_data { 'a very long string' }
     amount { 100 }
     status { 'initial' }
     expires_at { 1.hour.from_now }
-    currency { 'EUR' }
     payment_method { create(:adyen_gateway) }
 
     association :user

--- a/spec/services/spree_adyen/payment_sessions/create_spec.rb
+++ b/spec/services/spree_adyen/payment_sessions/create_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe SpreeAdyen::PaymentSessions::Create do
+  subject(:service) { described_class.new(order: order, user: user, amount: amount, payment_method: payment_method).call }
+
+  let(:order) { create(:order) }
+  let(:user) { create(:user) }
+  let(:amount) { 100 }
+  let(:payment_method) { create(:adyen_gateway) }
+
+  let(:existing_payment_session) do
+    create(:payment_session,
+      order: payment_order,
+      status: payment_status,
+      expires_at: 1.hour.from_now,
+      user: payment_user,
+      amount: payment_amount,
+      payment_method: payment_payment_method
+    )
+  end
+
+  before do
+    # we use expires_at from the cassette, so we need to freeze the time
+    Timecop.freeze('2025-07-07T0:00:00+02:00')
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it 'creates a payment session' do
+    VCR.use_cassette('payment_sessions/success') do
+      expect { service }.to change(SpreeAdyen::PaymentSession, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
* added currency validation (needs to be the same as orders currency)
* auto-supply currency from order
* adyen_id should be unique for entire system, not per payment method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a service to handle creation of payment sessions, improving management of payment session records.
* **Bug Fixes**
  * Enforced stricter currency consistency between payment sessions and their associated orders.
  * Updated uniqueness validation for payment session IDs to prevent duplicates across all payment methods.
* **Tests**
  * Added new tests to verify correct creation of payment sessions.
* **Chores**
  * Updated test factories to generate unique payment session IDs and removed default currency assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->