### PR TITLE
add client_key to payment session serializer

### DIFF
--- a/app/serializers/spree_adyen/api/v2/storefront/payment_session_serializer.rb
+++ b/app/serializers/spree_adyen/api/v2/storefront/payment_session_serializer.rb
@@ -7,6 +7,10 @@ module SpreeAdyen
 
           attributes :adyen_id, :amount, :currency, :adyen_data, :status, :expires_at
 
+          attribute :client_key do |object|
+            object.payment_method.preferred_client_key
+          end
+
           belongs_to :order, serializer: ::Spree::Api::Dependencies.storefront_cart_serializer.constantize
           belongs_to :payment_method, serializer: ::Spree::Api::Dependencies.storefront_payment_method_serializer.constantize
           belongs_to :user, serializer: ::Spree::Api::Dependencies.storefront_user_serializer.constantize

--- a/spec/requests/spree/api/v2/storefront/adyen/payment_sessions_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/adyen/payment_sessions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'API V2 Storefront Adyen Payment Sessions', type: :request do
   let(:store) { Spree::Store.default }
   let(:user) { create(:user) }
   let(:order) { create(:order_with_line_items, user: nil, store: store, state: :payment, total: 100) }
-  let!(:adyen_gateway) { create(:adyen_gateway, stores: [store]) }
+  let!(:adyen_gateway) { create(:adyen_gateway, stores: [store], preferred_client_key: 'test_client_key') }
   let(:order_token) { order.token }
 
   let(:headers) {
@@ -48,6 +48,7 @@ RSpec.describe 'API V2 Storefront Adyen Payment Sessions', type: :request do
             expect(json_data['attributes']['amount']).to eq(amount.to_f.to_s)
             expect(json_data['attributes']['status']).to eq('initial')
             expect(json_data['attributes']['adyen_id']).to be_present
+            expect(json_data['attributes']['client_key']).to eq('test_client_key')
             expect(json_data['attributes']['adyen_data']).to be_present
 
             # Verify relationships


### PR DESCRIPTION
issue:
- client needs client key value for mobile integration

solution:
- add client_api to the response of storefront API payload_sessions

api docs changes:
- https://github.com/spree/spree/pull/12978