### PR TITLE
store payment method id in reference

### DIFF
--- a/app/services/spree_adyen/webhooks/event.rb
+++ b/app/services/spree_adyen/webhooks/event.rb
@@ -13,8 +13,12 @@ module SpreeAdyen
         event_data
       end
 
+      def order_number
+        @order_number ||= merchant_reference.split('_')[0]
+      end
+
       def payment_method_id
-        @payment_method_id ||= additional_data['metadata.spree_payment_method_id']
+        @payment_method_id ||= merchant_reference.split('_')[1]
       end
 
       def code

--- a/spec/presenters/spree_adyen/payment_sessions/request_payload_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/payment_sessions/request_payload_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
       }
     end
 
-    let(:expected_reference) { 'R123456789_1' }
+    let(:expected_reference) { "R123456789_#{payment_method.id}_1" }
 
     describe '#to_h' do
       subject(:payload) { serializer.to_h }
@@ -63,7 +63,7 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
       end
 
       context 'when payment session already exists' do
-        let(:expected_reference) { 'R123456789_2' }
+        let(:expected_reference) { "R123456789_#{payment_method.id}_2" }
 
         before do
           create(:payment_session, deleted_at: 1.day.ago, amount: order.total_minus_store_credits, order: order, adyen_id: 'CS4FBB6F827EC53AC7')

--- a/spec/presenters/spree_adyen/payments/request_payload_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/payments/request_payload_presenter_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe SpreeAdyen::Payments::RequestPayloadPresenter do
+  subject(:serializer) { described_class.new(source: source, amount_in_cents: amount, gateway_options: gateway_options) }
+
+  let(:source) { create(:credit_card, gateway_payment_profile_id: '12345', payment_method: payment_method) }
+  let(:gateway_options) { { order_id: 'R123456789-PX6H2G23' } }
+  let(:amount) { 100 * 100 }
+
+  before do
+    create(:payment,
+      number: 'PX6H2G23',
+      order: order,
+      payment_method: payment_method,
+      source: source,
+      amount: 100
+    )
+  end
+
+  let(:order) { create(:order_with_line_items, number: 'R123456789', total: 100, user: user, currency: 'USD') }
+  let(:user) { create(:user) }
+  let(:payment_method) { create(:adyen_gateway, preferred_merchant_account: 'SpreeCommerceECOM') }
+
+  context 'with valid params' do
+    let(:expected_payload) do
+      {
+        metadata: {
+          spree_payment_method_id: payment_method.id,
+          spree_order_id: order.number
+        },
+        amount: {
+          value: amount,
+          currency: order.currency
+        },
+        shopperInteraction: "ContAuth",
+        reference: expected_reference,
+        recurringProcessingModel: "UnscheduledCardOnFile",
+        merchantAccount: 'SpreeCommerceECOM',
+        paymentMethod: {
+          storedPaymentMethodId: '12345',
+          type: 'scheme'
+        },
+        channel: 'Web',
+        shopperReference: "customer_#{user.id}"
+      }
+    end
+
+    let(:expected_reference) { "R123456789_#{payment_method.id}_PX6H2G23" }
+
+    describe '#to_h' do
+      subject(:payload) { serializer.to_h }
+
+      it 'returns a valid payload' do
+        expect(payload).to eq(expected_payload)
+      end
+    end
+  end
+end

--- a/spec/services/spree_adyen/webhooks/event_spec.rb
+++ b/spec/services/spree_adyen/webhooks/event_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe SpreeAdyen::Webhooks::Event do
+  subject(:event) { described_class.new(event_data: event_data) }
+
+  let(:event_data) do
+    {
+      "live": "false",
+      "notificationItems": [
+        {
+          "NotificationRequestItem": {
+            "additionalData": {
+              "expiryDate": "03/2030",
+              "authCode": '12345',
+              "cardSummary": "0004",
+              "isCardCommercial": "something",
+              "threeds2.cardEnrolled": "false",
+              "checkoutSessionId": 'CS4FBB6F827EC53AC7',
+              "paymentMethod": "mc",
+              "checkout.cardAddedBrand": "**",
+              "storedPaymentMethodId": "HF7Z59JSZZSBJWT5",
+              "hmacSignature": "m1dnv+xFOwkdlMhiACVsms6Z/wmal0tuodl4qzD0BTs="
+            },
+            "amount": {
+              "currency": "EUR",
+              "value": 1000
+            },
+            "eventCode": "AUTHORISATION",
+            "eventDate": "2025-07-04T12:59:19+02:00",
+            "merchantAccountCode": "SpreeCommerceECOM",
+            "merchantReference": "R123456789_12345_PX6H2G23",
+            "operations": [
+              "CANCEL",
+              "CAPTURE",
+              "REFUND"
+            ],
+            "paymentMethod": "mc",
+            "pspReference": "123432123",
+            "reason": "087969:0004:03/2030",
+            "success": "true"
+          }
+        }
+      ]
+    }
+  end
+
+  describe '#order_number' do
+    it 'returns the order number' do
+      expect(event.order_number).to eq('R123456789')
+    end
+  end
+
+  describe '#payment_method_id' do
+    it 'returns the payment method id' do
+      expect(event.payment_method_id).to eq('12345')
+    end
+  end
+end


### PR DESCRIPTION
metadata was not present in autorisation webhooks other than CC so:

- cannot validate hmac
- payment source was not set
- endpoint returns 404 :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reference formatting in payment payloads to include order number, payment method ID, and sequence, enhancing reliability when processing webhook events.
* **Bug Fixes**
  * Webhook event handling now reliably extracts order and payment method information from the reference string, even when metadata is missing.
* **Tests**
  * Added and updated tests to verify new reference formats and ensure correct extraction of order and payment method data from webhook events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->