### PR TITLE
add link payment link to adyen dashboard

### DIFF
--- a/app/models/spree_adyen/gateway.rb
+++ b/app/models/spree_adyen/gateway.rb
@@ -168,6 +168,12 @@ module SpreeAdyen
       'spree_adyen'
     end
 
+    def gateway_dashboard_payment_url(payment)
+      return if payment.transaction_id.blank?
+
+      "https://ca-#{environment}.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=#{payment.transaction_id}&txType=Payment"
+    end
+
     def reusable_sources(order)
       if order.completed?
         sources_by_order order


### PR DESCRIPTION
add missing `gateway_dashboard_payment_url` to SpreeAdyen::Gateway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a direct link from payments to the Adyen Dashboard when a PSP reference is available.
  - The link automatically targets the correct environment (test or live) based on configuration.
  - If no PSP reference is present, the link is not shown.

- Tests
  - Added comprehensive tests for URL generation across test/live environments.
  - Verified behavior when a PSP reference is missing to ensure no link is produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->