### PR TITLE
Updaye application info

### DIFF
--- a/app/presenters/spree_adyen/application_info_presenter.rb
+++ b/app/presenters/spree_adyen/application_info_presenter.rb
@@ -8,7 +8,11 @@ module SpreeAdyen
           externalPlatform: {
             name: 'Spree Commerce',
             version: Spree.version,
-            integrator: 'Spree Adyen'
+            integrator: 'Vendo Connect Inc.'
+          },
+          merchantApplication: {
+            name: defined?(SpreeEnterprise) ? 'Enterprise Edition' : 'Community Edition',
+            version: SpreeAdyen.version
           }
         }
       }

--- a/lib/spree_adyen.rb
+++ b/lib/spree_adyen.rb
@@ -9,4 +9,8 @@ module SpreeAdyen
   def self.queue
     'default'
   end
+
+  def self.version
+    VERSION
+  end
 end

--- a/spec/presenters/spree_adyen/application_info_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/application_info_presenter_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe SpreeAdyen::ApplicationInfoPresenter do
         externalPlatform: {
           name: 'Spree Commerce',
           version: '42.0.0',
-          integrator: 'Spree Adyen'
+          integrator: 'Vendo Connect Inc.'
+        },
+        merchantApplication: {
+          name: 'Community Edition',
+          version: '0.0.1'
         }
       }
     }
@@ -17,6 +21,7 @@ RSpec.describe SpreeAdyen::ApplicationInfoPresenter do
 
   before do
     allow(Spree).to receive(:version).and_return('42.0.0')
+    allow(SpreeAdyen).to receive(:version).and_return('0.0.1')
   end
 
   it 'returns the correct hash' do

--- a/spec/presenters/spree_adyen/payment_sessions/request_payload_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/payment_sessions/request_payload_presenter_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
 
   before do
     allow(Spree).to receive(:version).and_return('42.0.0')
+    allow(SpreeAdyen).to receive(:version).and_return('0.0.1')
   end
 
   context 'with valid params' do
@@ -72,7 +73,11 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
           externalPlatform: {
             name: 'Spree Commerce',
             version: '42.0.0',
-            integrator: 'Spree Adyen'
+            integrator: 'Vendo Connect Inc.'
+          },
+          merchantApplication: {
+            name: 'Community Edition',
+            version: '0.0.1'
           }
         }
       }
@@ -97,7 +102,7 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
 
       context 'with iOS channel' do
         let(:channel) { 'iOS' }
-        
+
         it 'blocks google pay' do
           expect(payload).to include(blockedPaymentMethods: ['googlepay'])
         end
@@ -105,7 +110,7 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
 
       context 'with Android channel' do
         let(:channel) { 'Android' }
-        
+
         it 'blocks apple pay' do
           expect(payload).to include(blockedPaymentMethods: ['applepay'])
         end

--- a/spec/presenters/spree_adyen/payments/request_payload_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/payments/request_payload_presenter_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe SpreeAdyen::Payments::RequestPayloadPresenter do
 
   before do
     allow(Spree).to receive(:version).and_return('42.0.0')
+    allow(SpreeAdyen).to receive(:version).and_return('0.0.1')
   end
 
   context 'with valid params' do
@@ -49,7 +50,11 @@ RSpec.describe SpreeAdyen::Payments::RequestPayloadPresenter do
           externalPlatform: {
             name: 'Spree Commerce',
             version: '42.0.0',
-            integrator: 'Spree Adyen'
+            integrator: 'Vendo Connect Inc.'
+          },
+          merchantApplication: {
+            name: 'Community Edition',
+            version: '0.0.1'
           }
         }
       }

--- a/spec/presenters/spree_adyen/refund_payload_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/refund_payload_presenter_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe SpreeAdyen::RefundPayloadPresenter do
 
   before do
     allow(Spree).to receive(:version).and_return('42.0.0')
+    allow(SpreeAdyen).to receive(:version).and_return('0.0.1')
   end
 
   context 'with valid params' do
@@ -36,7 +37,11 @@ RSpec.describe SpreeAdyen::RefundPayloadPresenter do
           externalPlatform: {
             name: 'Spree Commerce',
             version: '42.0.0',
-            integrator: 'Spree Adyen'
+            integrator: 'Vendo Connect Inc.'
+          },
+          merchantApplication: {
+            name: 'Community Edition',
+            version: '0.0.1'
           }
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Application info now includes merchant application metadata with edition name (Enterprise or Community) and runtime version.
  - Updated integrator label in application info to “Vendo Connect Inc.”
  - Exposed the gem’s runtime version via a public method for easier access.

- Tests
  - Updated test expectations to include merchant application metadata and the new integrator label.
  - Added stubs for the runtime version in relevant specs to ensure consistent assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->