### PR TITLE
Handle refund webhooks, allow retrying refunds

### DIFF
--- a/app/controllers/spree_adyen/admin/refunds_controller_decorator.rb
+++ b/app/controllers/spree_adyen/admin/refunds_controller_decorator.rb
@@ -1,0 +1,19 @@
+module SpreeAdyen
+  module Admin
+    module RefundsControllerDecorator
+      def retry
+        result = SpreeAdyen::Refunds::Retry.call(refund: @refund)
+
+        if result.success?
+          flash[:success] = Spree.t(:refund_retry_submitted)
+        else
+          flash[:error] = result.value
+        end
+
+        redirect_to spree.edit_admin_order_path(@refund.payment.order)
+      end
+    end
+  end
+end
+
+Spree::Admin::RefundsController.prepend(SpreeAdyen::Admin::RefundsControllerDecorator) if defined?(Spree::Admin::RefundsController)

--- a/app/jobs/spree_adyen/webhooks/process_refund_event_job.rb
+++ b/app/jobs/spree_adyen/webhooks/process_refund_event_job.rb
@@ -1,0 +1,10 @@
+module SpreeAdyen
+  module Webhooks
+    class ProcessRefundEventJob < SpreeAdyen::BaseJob
+      def perform(payload)
+        event = SpreeAdyen::Webhooks::Event.new(event_data: payload)
+        SpreeAdyen::Webhooks::EventProcessors::RefundEventProcessor.new(event).call
+      end
+    end
+  end
+end

--- a/app/jobs/spree_adyen/webhooks/process_refund_failed_event_job.rb
+++ b/app/jobs/spree_adyen/webhooks/process_refund_failed_event_job.rb
@@ -1,0 +1,10 @@
+module SpreeAdyen
+  module Webhooks
+    class ProcessRefundFailedEventJob < SpreeAdyen::BaseJob
+      def perform(payload)
+        event = SpreeAdyen::Webhooks::Event.new(event_data: payload)
+        SpreeAdyen::Webhooks::EventProcessors::RefundEventProcessor.new(event).call
+      end
+    end
+  end
+end

--- a/app/models/spree_adyen/gateway.rb
+++ b/app/models/spree_adyen/gateway.rb
@@ -224,6 +224,12 @@ module SpreeAdyen
         raise Spree::PaymentMethod::WebhookSignatureError, 'Invalid HMAC signature'
       end
 
+      # Handle refund events directly — they don't use payment sessions
+      if event.code.in?(%w[REFUND REFUND_FAILED])
+        handle_refund_webhook(event)
+        return nil
+      end
+
       # Find payment session — scoped to this gateway
       payment_session = event.session_id.present? ?
         Spree::PaymentSessions::Adyen.find_by(payment_method: self, external_id: event.session_id) : nil
@@ -465,6 +471,15 @@ module SpreeAdyen
       JSON.parse(error.response)
     rescue JSON::ParserError, TypeError
       { 'message' => error.msg }
+    end
+
+    def handle_refund_webhook(event)
+      handler = SpreeAdyen.event_handlers[event.code]
+      return unless handler
+
+      handler
+        .set(wait: SpreeAdyen::Config.webhook_delay_in_seconds.seconds)
+        .perform_later(event.payload)
     end
 
     def valid_hmac?(webhook_request_item)

--- a/app/models/spree_adyen/refund_decorator.rb
+++ b/app/models/spree_adyen/refund_decorator.rb
@@ -1,0 +1,20 @@
+module SpreeAdyen
+  module RefundDecorator
+    ADYEN_REFUND_STATUS_METAFIELD_KEY = 'adyen.refund_status'.freeze
+    ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY = 'adyen.refund_error_message'.freeze
+
+    ADYEN_REFUND_STATUS_PENDING = 'pending'.freeze
+    ADYEN_REFUND_STATUS_SUBMITTED = 'submitted'.freeze
+    ADYEN_REFUND_STATUS_REJECTED = 'rejected'.freeze
+
+    def adyen_refund_status
+      get_metafield(ADYEN_REFUND_STATUS_METAFIELD_KEY)&.value || ADYEN_REFUND_STATUS_PENDING
+    end
+
+    def adyen_refund_error_message
+      get_metafield(ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY)&.value
+    end
+  end
+end
+
+Spree::Refund.prepend(SpreeAdyen::RefundDecorator)

--- a/app/services/spree_adyen/refunds/retry.rb
+++ b/app/services/spree_adyen/refunds/retry.rb
@@ -4,21 +4,23 @@ module SpreeAdyen
       prepend Spree::ServiceModule::Base
 
       def call(refund:)
-        return failure('Refund is not rejected') unless refund.adyen_refund_status == SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED
+        refund.with_lock do
+          return failure('Refund is not rejected') unless refund.adyen_refund_status == SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED
 
-        payment = refund.payment
-        credit_cents = Spree::Money.new(refund.amount.to_f, currency: refund.currency).amount_in_cents
+          payment = refund.payment
+          credit_cents = Spree::Money.new(refund.amount.to_f, currency: refund.currency).amount_in_cents
 
-        response = payment.payment_method.credit(credit_cents, payment.source, payment.transaction_id, originator: refund)
+          response = payment.payment_method.credit(credit_cents, payment.source, payment.transaction_id, originator: refund)
 
-        if response.success?
-          refund.update_columns(transaction_id: response.authorization)
-          refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_PENDING)
-          refund.get_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY)&.destroy
+          if response.success?
+            refund.update_columns(transaction_id: response.authorization)
+            refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_PENDING)
+            refund.get_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY)&.destroy
 
-          success(refund)
-        else
-          failure(response.params['message'] || response.message)
+            success(refund)
+          else
+            failure(response.params['message'] || response.message)
+          end
         end
       rescue Spree::Core::GatewayError => e
         failure(e.message)

--- a/app/services/spree_adyen/refunds/retry.rb
+++ b/app/services/spree_adyen/refunds/retry.rb
@@ -1,0 +1,28 @@
+module SpreeAdyen
+  module Refunds
+    class Retry
+      prepend Spree::ServiceModule::Base
+
+      def call(refund:)
+        return failure('Refund is not rejected') unless refund.adyen_refund_status == SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED
+
+        payment = refund.payment
+        credit_cents = Spree::Money.new(refund.amount.to_f, currency: refund.currency).amount_in_cents
+
+        response = payment.payment_method.credit(credit_cents, payment.source, payment.transaction_id, originator: refund)
+
+        if response.success?
+          refund.update_columns(transaction_id: response.authorization)
+          refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_PENDING)
+          refund.get_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY)&.destroy
+
+          success(refund)
+        else
+          failure(response.params['message'] || response.message)
+        end
+      rescue Spree::Core::GatewayError => e
+        failure(e.message)
+      end
+    end
+  end
+end

--- a/app/services/spree_adyen/webhooks/event_processors/refund_event_processor.rb
+++ b/app/services/spree_adyen/webhooks/event_processors/refund_event_processor.rb
@@ -21,6 +21,7 @@ module SpreeAdyen
 
             if event.success? && event.code != 'REFUND_FAILED'
               refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_SUBMITTED)
+              refund.get_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY)&.destroy
             else
               refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED)
               refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY, event.fetch('reason'))

--- a/app/services/spree_adyen/webhooks/event_processors/refund_event_processor.rb
+++ b/app/services/spree_adyen/webhooks/event_processors/refund_event_processor.rb
@@ -1,0 +1,47 @@
+module SpreeAdyen
+  class RefundError < StandardError; end
+
+  module Webhooks
+    module EventProcessors
+      class RefundEventProcessor
+        class Error < StandardError; end
+
+        def initialize(event)
+          @event = event
+        end
+
+        def call
+          Rails.logger.info("[SpreeAdyen][#{event_id}]: Started processing refund event")
+          order = Spree::Order.find_by!(number: event.order_number)
+
+          order.with_lock do
+            payment_method = SpreeAdyen::Gateway.find(event.payment_method_id)
+            payment = order.payments.find_by!(response_code: event.fetch('originalReference'), payment_method: payment_method)
+            refund = payment.refunds.find_by!(transaction_id: event.psp_reference)
+
+            if event.success? && event.code != 'REFUND_FAILED'
+              refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_SUBMITTED)
+            else
+              refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED)
+              refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY, event.fetch('reason'))
+
+              Rails.error.report(
+                SpreeAdyen::RefundError.new(event.fetch('reason')),
+                context: { order_id: order.id, refund_id: refund.id, event: event.payload },
+                source: 'spree_adyen'
+              )
+            end
+          end
+
+          Rails.logger.info("[SpreeAdyen][#{event_id}]: Finished processing refund event")
+        end
+
+        private
+
+        attr_reader :event
+
+        delegate :id, to: :event, prefix: true
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,16 @@ Spree::Core::Engine.add_routes do
       end
     end
   end
+
+  namespace :admin, path: Spree.admin_path do
+    resources :orders, only: [] do
+      resources :payments, only: [] do
+        resources :refunds, only: [] do
+          member do
+            put :retry
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/spree_adyen/engine.rb
+++ b/lib/spree_adyen/engine.rb
@@ -30,19 +30,25 @@ module SpreeAdyen
       Rails.application.config.spree_adyen.event_handlers.merge!(
         'AUTHORISATION' => SpreeAdyen::Webhooks::ProcessAuthorisationEventJob,
         'CAPTURE' => SpreeAdyen::Webhooks::ProcessCaptureEventJob,
-        'CANCELLATION' => SpreeAdyen::Webhooks::ProcessCancellationEventJob
+        'CANCELLATION' => SpreeAdyen::Webhooks::ProcessCancellationEventJob,
+        'REFUND' => SpreeAdyen::Webhooks::ProcessRefundEventJob,
+        'REFUND_FAILED' => SpreeAdyen::Webhooks::ProcessRefundFailedEventJob
       )
 
       Rails.application.config.spree_adyen.events.merge!(
         'AUTHORISATION' => SpreeAdyen::Webhooks::Event,
         'CAPTURE' => SpreeAdyen::Webhooks::Event,
-        'CANCELLATION' => SpreeAdyen::Webhooks::Event
+        'CANCELLATION' => SpreeAdyen::Webhooks::Event,
+        'REFUND' => SpreeAdyen::Webhooks::Event,
+        'REFUND_FAILED' => SpreeAdyen::Webhooks::Event
       )
 
       Rails.application.config.spree_adyen.hmac_validators.merge!(
         'AUTHORISATION' => SpreeAdyen::Webhooks::StandardHmacValidator,
         'CAPTURE' => SpreeAdyen::Webhooks::StandardHmacValidator,
-        'CANCELLATION' => SpreeAdyen::Webhooks::StandardHmacValidator
+        'CANCELLATION' => SpreeAdyen::Webhooks::StandardHmacValidator,
+        'REFUND' => SpreeAdyen::Webhooks::StandardHmacValidator,
+        'REFUND_FAILED' => SpreeAdyen::Webhooks::StandardHmacValidator
       )
     end
 

--- a/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::RefundsController, type: :controller do
+  stub_authorization!
+  render_views
+
+  let(:user) { create(:admin_user) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(Spree.ability_class.new(user))
+  end
+
+  let(:order) { create(:completed_order_with_totals, number: 'R142767632') }
+  let(:payment_method) do
+    create(:adyen_gateway,
+      stores: [Spree::Store.default],
+      preferred_api_key: 'secret',
+      preferred_merchant_account: 'SpreeCommerceECOM',
+      preferred_test_mode: true
+    )
+  end
+  let(:payment) { create(:payment, state: 'completed', amount: 20.0, order: order, payment_method: payment_method, response_code: 'ADYEN_PAYMENT_PSP_REFERENCE') }
+  let!(:refund) { create(:refund, payment: payment, amount: 8.0, transaction_id: 'old_psp_reference') }
+
+  before do
+    refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED)
+    refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY, 'Insufficient in-process funds on account')
+  end
+
+  describe 'PUT #retry' do
+    subject { put :retry, params: { order_id: order.to_param, payment_id: payment.to_param, id: refund.to_param } }
+
+    context 'when the retry is successful' do
+      it 'redirects to the order page with a success flash' do
+        VCR.use_cassette('payment_api/create_refund/success_partial') do
+          subject
+
+          expect(response).to redirect_to spree.edit_admin_order_path(order)
+          expect(flash[:success]).to eq(Spree.t(:refund_retry_submitted))
+        end
+      end
+
+      it 'updates the refund' do
+        VCR.use_cassette('payment_api/create_refund/success_partial') do
+          subject
+
+          refund.reload
+          expect(refund.transaction_id).to eq('ADYEN_PSP_REFERENCE')
+          expect(refund.adyen_refund_status).to eq('pending')
+          expect(refund.adyen_refund_error_message).to be_nil
+        end
+      end
+    end
+
+    context 'when the retry fails' do
+      it 'redirects to the order page with an error flash' do
+        VCR.use_cassette('payment_api/create_refund/failure/invalid_amount') do
+          subject
+
+          expect(response).to redirect_to spree.edit_admin_order_path(order)
+          expect(flash[:error]).to include("Field 'amount' is not valid.")
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/spree_adyen/webhooks_controller_spec.rb
+++ b/spec/controllers/spree_adyen/webhooks_controller_spec.rb
@@ -564,6 +564,21 @@ RSpec.describe SpreeAdyen::WebhooksController, type: :controller do
             expect(response).to have_http_status(:ok)
             expect(refund.reload.adyen_refund_status).to eq('submitted')
           end
+
+          context 'when refund was previously rejected' do
+            before do
+              refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_REJECTED)
+              refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY, 'Insufficient in-process funds on account')
+            end
+
+            it 'clears the error message' do
+              perform_enqueued_jobs { subject }
+
+              refund.reload
+              expect(refund.adyen_refund_status).to eq('submitted')
+              expect(refund.adyen_refund_error_message).to be_nil
+            end
+          end
         end
 
         context 'when refund failed' do

--- a/spec/controllers/spree_adyen/webhooks_controller_spec.rb
+++ b/spec/controllers/spree_adyen/webhooks_controller_spec.rb
@@ -544,6 +544,89 @@ RSpec.describe SpreeAdyen::WebhooksController, type: :controller do
           end
         end
       end
+
+      describe 'refund event' do
+        let!(:payment) { create(:payment, state: 'completed', order: order, payment_method: payment_method, amount: 100.0, response_code: response_code) }
+        let(:response_code) { 'ABC123' }
+        let!(:refund) { create(:refund, payment: payment, amount: 10.0, transaction_id: 'refund_psp_reference') }
+
+        context 'when refund is confirmed' do
+          let(:params) { JSON.parse(file_fixture('webhooks/refund/success.json').read) }
+
+          it 'schedules a job' do
+            expect { subject }.to have_enqueued_job(SpreeAdyen::Webhooks::ProcessRefundEventJob)
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'marks the refund as submitted' do
+            perform_enqueued_jobs { subject }
+
+            expect(response).to have_http_status(:ok)
+            expect(refund.reload.adyen_refund_status).to eq('submitted')
+          end
+        end
+
+        context 'when refund failed' do
+          let(:params) { JSON.parse(file_fixture('webhooks/refund/failure.json').read) }
+
+          before do
+            allow(Rails.error).to receive(:report)
+          end
+
+          it 'marks the refund as rejected' do
+            perform_enqueued_jobs { subject }
+
+            expect(response).to have_http_status(:ok)
+            expect(refund.reload.adyen_refund_status).to eq('rejected')
+            expect(refund.adyen_refund_error_message).to eq('Insufficient in-process funds on account')
+          end
+
+          it 'reports an error' do
+            perform_enqueued_jobs { subject }
+
+            expect(Rails.error).to have_received(:report).with(
+              SpreeAdyen::RefundError.new('Insufficient in-process funds on account'),
+              context: { order_id: order.id, refund_id: refund.id, event: anything },
+              source: 'spree_adyen'
+            )
+          end
+        end
+      end
+
+      describe 'refund_failed event' do
+        let!(:payment) { create(:payment, state: 'completed', order: order, payment_method: payment_method, amount: 100.0, response_code: response_code) }
+        let(:response_code) { 'ABC123' }
+        let!(:refund) { create(:refund, payment: payment, amount: 10.0, transaction_id: 'refund_psp_reference') }
+
+        let(:params) { JSON.parse(file_fixture('webhooks/refund_failed/failure.json').read) }
+
+        before do
+          allow(Rails.error).to receive(:report)
+        end
+
+        it 'schedules a job' do
+          expect { subject }.to have_enqueued_job(SpreeAdyen::Webhooks::ProcessRefundFailedEventJob)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'marks the refund as rejected' do
+          perform_enqueued_jobs { subject }
+
+          expect(response).to have_http_status(:ok)
+          expect(refund.reload.adyen_refund_status).to eq('rejected')
+          expect(refund.adyen_refund_error_message).to eq('Issuer declined the refund')
+        end
+
+        it 'reports an error' do
+          perform_enqueued_jobs { subject }
+
+          expect(Rails.error).to have_received(:report).with(
+            SpreeAdyen::RefundError.new('Issuer declined the refund'),
+            context: { order_id: order.id, refund_id: refund.id, event: anything },
+            source: 'spree_adyen'
+          )
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/files/webhooks/refund/failure.json
+++ b/spec/fixtures/files/webhooks/refund/failure.json
@@ -1,0 +1,22 @@
+{
+  "live":"false",
+  "notificationItems":[
+     {
+        "NotificationRequestItem":{
+           "amount":{
+              "currency":"EUR",
+              "value":1000
+           },
+           "eventCode":"REFUND",
+           "eventDate":"2025-11-21T08:00:00+02:00",
+           "merchantAccountCode":"SpreeCommerceECOM",
+           "merchantReference":"1234567890_1_ABC123_refund_42",
+           "originalReference":"ABC123",
+           "paymentMethod":"mc",
+           "pspReference":"refund_psp_reference",
+           "reason":"Insufficient in-process funds on account",
+           "success":"false"
+        }
+     }
+  ]
+}

--- a/spec/fixtures/files/webhooks/refund/success.json
+++ b/spec/fixtures/files/webhooks/refund/success.json
@@ -1,0 +1,22 @@
+{
+  "live":"false",
+  "notificationItems":[
+     {
+        "NotificationRequestItem":{
+           "amount":{
+              "currency":"EUR",
+              "value":1000
+           },
+           "eventCode":"REFUND",
+           "eventDate":"2025-11-21T08:00:00+02:00",
+           "merchantAccountCode":"SpreeCommerceECOM",
+           "merchantReference":"1234567890_1_ABC123_refund_42",
+           "originalReference":"ABC123",
+           "paymentMethod":"mc",
+           "pspReference":"refund_psp_reference",
+           "reason":"",
+           "success":"true"
+        }
+     }
+  ]
+}

--- a/spec/fixtures/files/webhooks/refund_failed/failure.json
+++ b/spec/fixtures/files/webhooks/refund_failed/failure.json
@@ -1,0 +1,22 @@
+{
+  "live":"false",
+  "notificationItems":[
+     {
+        "NotificationRequestItem":{
+           "amount":{
+              "currency":"EUR",
+              "value":1000
+           },
+           "eventCode":"REFUND_FAILED",
+           "eventDate":"2025-11-21T08:00:00+02:00",
+           "merchantAccountCode":"SpreeCommerceECOM",
+           "merchantReference":"1234567890_1_ABC123_refund_42",
+           "originalReference":"ABC123",
+           "paymentMethod":"mc",
+           "pspReference":"refund_psp_reference",
+           "reason":"Issuer declined the refund",
+           "success":"true"
+        }
+     }
+  ]
+}

--- a/spec/models/spree_adyen/gateway_spec.rb
+++ b/spec/models/spree_adyen/gateway_spec.rb
@@ -738,9 +738,45 @@ RSpec.describe SpreeAdyen::Gateway do
       end
     end
 
-    context 'with unsupported event' do
+    context 'with REFUND event' do
+      include ActiveJob::TestHelper
+
       before do
         authorisation_payload['notificationItems'][0]['NotificationRequestItem']['eventCode'] = 'REFUND'
+      end
+
+      it 'returns nil' do
+        expect(gateway.parse_webhook_event(authorisation_payload.to_json, {})).to be_nil
+      end
+
+      it 'enqueues the refund event job' do
+        expect {
+          gateway.parse_webhook_event(authorisation_payload.to_json, {})
+        }.to have_enqueued_job(SpreeAdyen::Webhooks::ProcessRefundEventJob)
+      end
+    end
+
+    context 'with REFUND_FAILED event' do
+      include ActiveJob::TestHelper
+
+      before do
+        authorisation_payload['notificationItems'][0]['NotificationRequestItem']['eventCode'] = 'REFUND_FAILED'
+      end
+
+      it 'returns nil' do
+        expect(gateway.parse_webhook_event(authorisation_payload.to_json, {})).to be_nil
+      end
+
+      it 'enqueues the refund failed event job' do
+        expect {
+          gateway.parse_webhook_event(authorisation_payload.to_json, {})
+        }.to have_enqueued_job(SpreeAdyen::Webhooks::ProcessRefundFailedEventJob)
+      end
+    end
+
+    context 'with unsupported event' do
+      before do
+        authorisation_payload['notificationItems'][0]['NotificationRequestItem']['eventCode'] = 'CHARGEBACK'
       end
 
       it 'returns nil' do

--- a/spec/services/spree_adyen/refunds/retry_spec.rb
+++ b/spec/services/spree_adyen/refunds/retry_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+RSpec.describe SpreeAdyen::Refunds::Retry do
+  subject(:result) { described_class.call(refund: refund) }
+
+  let(:gateway) do
+    create(
+      :adyen_gateway,
+      stores: [Spree::Store.default],
+      preferred_api_key: 'secret',
+      preferred_merchant_account: 'SpreeCommerceECOM',
+      preferred_test_mode: true
+    )
+  end
+
+  let(:order) { create(:order, total: 10, number: 'R142767632') }
+  let(:payment) { create(:payment, state: 'completed', order: order, payment_method: gateway, amount: 10.0, response_code: 'ADYEN_PAYMENT_PSP_REFERENCE') }
+  let(:refund) { create(:refund, payment: payment, amount: 8.0, transaction_id: 'old_psp_reference') }
+
+  before do
+    refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, 'rejected')
+    refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_ERROR_MESSAGE_METAFIELD_KEY, 'Insufficient in-process funds on account')
+  end
+
+  context 'when the refund is not rejected' do
+    before do
+      refund.set_metafield(SpreeAdyen::RefundDecorator::ADYEN_REFUND_STATUS_METAFIELD_KEY, 'submitted')
+    end
+
+    it 'returns failure' do
+      expect(result).to be_failure
+      expect(result.value).to eq('Refund is not rejected')
+    end
+  end
+
+  context 'when the refund is successful' do
+    it 'returns success' do
+      VCR.use_cassette('payment_api/create_refund/success_partial') do
+        expect(result).to be_success
+        expect(result.value).to eq(refund)
+      end
+    end
+
+    it 'updates the transaction_id' do
+      VCR.use_cassette('payment_api/create_refund/success_partial') do
+        result
+
+        expect(refund.reload.transaction_id).to eq('ADYEN_PSP_REFERENCE')
+      end
+    end
+
+    it 'resets the refund status to pending and clears the error message' do
+      VCR.use_cassette('payment_api/create_refund/success_partial') do
+        result
+
+        refund.reload
+        expect(refund.adyen_refund_status).to eq('pending')
+        expect(refund.adyen_refund_error_message).to be_nil
+      end
+    end
+  end
+
+  context 'when the refund fails with a gateway error' do
+    it 'returns failure with error message' do
+      VCR.use_cassette('payment_api/create_refund/failure/invalid_amount') do
+        expect(result).to be_failure
+        expect(result.value).to include("Field 'amount' is not valid.")
+      end
+    end
+
+    it 'does not update the transaction_id' do
+      VCR.use_cassette('payment_api/create_refund/failure/invalid_amount') do
+        result
+
+        expect(refund.reload.transaction_id).to eq('old_psp_reference')
+      end
+    end
+
+    it 'does not change the metafields' do
+      VCR.use_cassette('payment_api/create_refund/failure/invalid_amount') do
+        result
+
+        expect(refund.reload.adyen_refund_status).to eq('rejected')
+        expect(refund.adyen_refund_error_message).to eq('Insufficient in-process funds on account')
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry rejected refunds from the admin order UI with a new retry action and route; shows success/error flash messages
  * Refund status tracking added: pending, submitted, rejected, with stored error messages visible where applicable
  * Webhook handling for REFUND and REFUND_FAILED to update refund status asynchronously

* **Tests**
  * Added controller, webhook, service specs and webhook fixture payloads covering success and failure flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->