### PR TITLE
Add new `use_legacy_adyen_payment_sessions` config option

### DIFF
--- a/app/models/spree_adyen/order_decorator.rb
+++ b/app/models/spree_adyen/order_decorator.rb
@@ -5,6 +5,8 @@ module SpreeAdyen
     end
 
     def outdate_payment_sessions
+      return unless SpreeAdyen::Config[:use_legacy_adyen_payment_sessions]
+
       adyen_payment_sessions
         .where.not(currency: currency).or(adyen_payment_sessions.where.not(amount: total_minus_store_credits))
         .with_status(:initial)

--- a/app/presenters/spree_adyen/payment_sessions/request_payload_presenter.rb
+++ b/app/presenters/spree_adyen/payment_sessions/request_payload_presenter.rb
@@ -50,8 +50,16 @@ module SpreeAdyen
         [
           order.number,
           payment_method.id,
-          order.adyen_payment_sessions.with_deleted.count + 1
+          payment_sessions_count + 1
         ].join('_')
+      end
+
+      def payment_sessions_count
+        if SpreeAdyen::Config[:use_legacy_adyen_payment_sessions]
+          order.adyen_payment_sessions.with_deleted.count
+        else
+          order.payment_sessions.with_deleted.where(payment_method: payment_method).count
+        end
       end
 
       def channel_params

--- a/lib/spree_adyen/configuration.rb
+++ b/lib/spree_adyen/configuration.rb
@@ -12,6 +12,7 @@ module SpreeAdyen
     preference :payment_session_expiration_in_minutes, :integer, default: 60
     preference :webhook_delay_in_seconds, :integer, default: 5
     preference :use_legacy_webhook_handlers, :boolean, default: false
+    preference :use_legacy_adyen_payment_sessions, :boolean, default: false
 
     preference :credit_card_sources, :array, default: %i[
       accel

--- a/spec/models/spree_adyen/order_decorator_spec.rb
+++ b/spec/models/spree_adyen/order_decorator_spec.rb
@@ -33,8 +33,20 @@ RSpec.describe SpreeAdyen::OrderDecorator do
   describe '#outdate_payment_sessions' do
     subject(:outdate_payment_sessions) { order.outdate_payment_sessions }
 
-    it 'removes outdated (with wrong amount or currency) payment sessions' do
-      expect { outdate_payment_sessions }.to change { SpreeAdyen::PaymentSession.count }.by(-4)
+    context 'when use_legacy_adyen_payment_sessions is enabled' do
+      before { SpreeAdyen::Config[:use_legacy_adyen_payment_sessions] = true }
+
+      after { SpreeAdyen::Config[:use_legacy_adyen_payment_sessions] = false }
+
+      it 'removes outdated (with wrong amount or currency) payment sessions' do
+        expect { outdate_payment_sessions }.to change { SpreeAdyen::PaymentSession.count }.by(-4)
+      end
+    end
+
+    context 'when use_legacy_adyen_payment_sessions is disabled' do
+      it 'does not remove any payment sessions' do
+        expect { outdate_payment_sessions }.not_to change { SpreeAdyen::PaymentSession.count }
+      end
     end
   end
 

--- a/spec/presenters/spree_adyen/payment_sessions/request_payload_presenter_spec.rb
+++ b/spec/presenters/spree_adyen/payment_sessions/request_payload_presenter_spec.rb
@@ -139,8 +139,31 @@ RSpec.describe SpreeAdyen::PaymentSessions::RequestPayloadPresenter do
         let(:expected_reference) { "R123456789_#{payment_method.id}_2" }
 
         before do
+          Spree::PaymentSessions::Adyen.create!(
+            order: order,
+            payment_method: payment_method,
+            amount: order.total_minus_store_credits,
+            currency: order.currency,
+            status: 'pending',
+            external_id: 'CS4FBB6F827EC53AC7',
+            deleted_at: 1.day.ago
+          )
+        end
+
+        it 'returns a valid payload' do
+          expect(payload).to eq(expected_payload)
+        end
+      end
+
+      context 'when payment session already exists (legacy)' do
+        let(:expected_reference) { "R123456789_#{payment_method.id}_2" }
+
+        before do
+          SpreeAdyen::Config[:use_legacy_adyen_payment_sessions] = true
           create(:adyen_payment_session, deleted_at: 1.day.ago, amount: order.total_minus_store_credits, order: order, adyen_id: 'CS4FBB6F827EC53AC7')
         end
+
+        after { SpreeAdyen::Config[:use_legacy_adyen_payment_sessions] = false }
 
         it 'returns a valid payload' do
           expect(payload).to eq(expected_payload)


### PR DESCRIPTION
To completely disable old adyen payment session models, and only use Spree 5.4 Payment Sessions API by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option that enables switching between legacy and modern payment session handling modes for different operational requirements.

* **Tests**
  * Expanded test suite to comprehensively validate payment session management operations across both legacy and modern configuration modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->