### PR TITLE
Replaced the hardcoded URL construction with `gateway.webhook_url`

### DIFF
--- a/app/services/spree_adyen/gateways/configure.rb
+++ b/app/services/spree_adyen/gateways/configure.rb
@@ -45,9 +45,7 @@ module SpreeAdyen
       end
 
       def set_up_webhook_with_hmac_key
-        webhook_url = URI.parse(Spree::Core::Engine.routes.url_helpers.adyen_webhooks_url(host: gateway.stores.first.url))
-        webhook_url.scheme = 'https'
-        set_up_webhook_request = gateway.set_up_webhook(webhook_url.to_s)
+        set_up_webhook_request = gateway.set_up_webhook(gateway.webhook_url)
         return unless set_up_webhook_request.success?
 
         gateway.preferred_webhook_id = set_up_webhook_request.authorization

--- a/spec/services/spree_adyen/gateways/configure_spec.rb
+++ b/spec/services/spree_adyen/gateways/configure_spec.rb
@@ -39,6 +39,27 @@ RSpec.describe SpreeAdyen::Gateways::Configure do
                           .and change(gateway, :updated_at)
       end
     end
+
+    it 'registers the webhook using the v3 webhook url' do
+      VCR.use_cassette('gateways/configure/success/webhook_not_set_up') do
+        expect(gateway).to receive(:set_up_webhook).with(gateway.webhook_url).and_call_original
+        service
+      end
+    end
+
+    context 'with legacy webhook handlers enabled' do
+      before do
+        allow(SpreeAdyen::Config).to receive(:[]).and_call_original
+        allow(SpreeAdyen::Config).to receive(:[]).with(:use_legacy_webhook_handlers).and_return(true)
+      end
+
+      it 'registers the webhook using the legacy webhook url' do
+        VCR.use_cassette('gateways/configure/success/webhook_not_set_up') do
+          expect(gateway).to receive(:set_up_webhook).with("#{store.formatted_url}/adyen/webhooks").and_call_original
+          service
+        end
+      end
+    end
   end
 
   context 'when webhook is set up' do


### PR DESCRIPTION
This way we can properly support new Spree 5.4 Payment Sessions and old Spree installations